### PR TITLE
Replace httplib with libcurl for HTTP operations

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -30,4 +30,5 @@ jobs:
       duckdb_version: v1.5.0
       ci_tools_version: v1.5.0
       extension_name: elasticsearch
-      format_checks: "format;tidy"
+      # Remove tidy check until duckdb/extension-ci-tools#223 is resolved.
+      format_checks: "format"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,13 @@ set(TARGET_NAME elasticsearch)
 
 # DuckDB's extension distribution supports vcpkg. As such, dependencies can be
 # added in vcpkg.json and then used in cmake with find_package.
-find_package(OpenSSL REQUIRED)
+find_package(CURL REQUIRED)
 
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
 include_directories(src/include)
-include_directories(duckdb/third_party/httplib)
 
 set(EXTENSION_SOURCES src/elasticsearch_extension.cpp
                       src/elasticsearch_cache.cpp
@@ -25,9 +24,9 @@ set(EXTENSION_SOURCES src/elasticsearch_extension.cpp
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
-# Link OpenSSL in both the static library and the loadable extension.
-target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto)
-target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto)
+# Link libcurl in both the static library and the loadable extension.
+target_link_libraries(${EXTENSION_NAME} CURL::libcurl)
+target_link_libraries(${LOADABLE_EXTENSION_NAME} CURL::libcurl)
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/src/elasticsearch_client.cpp
+++ b/src/elasticsearch_client.cpp
@@ -1,9 +1,9 @@
 #include "elasticsearch_client.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/logging/log_type.hpp"
 
-#define CPPHTTPLIB_OPENSSL_SUPPORT
-#include "httplib.hpp"
+#include <curl/curl.h>
 
 #include <chrono>
 #include <thread>
@@ -20,63 +20,175 @@ static const std::unordered_set<int> RETRYABLE_STATUS_CODES = {
     504  // Gateway Timeout
 };
 
-// Format headers map as a string for logging.
-static std::string FormatHeaders(const duckdb_httplib_openssl::Headers &headers) {
-	std::string headers_str = "{";
-	bool first = true;
-	for (const auto &header : headers) {
-		if (!first) {
-			headers_str += ", ";
-		}
-		first = false;
-		headers_str += header.first + "='" + header.second + "'";
-	}
-	headers_str += "}";
-	return headers_str;
+// Callback for libcurl to write response body data.
+static size_t WriteCallback(char *ptr, size_t size, size_t nmemb, void *userdata) {
+	auto *response_body = static_cast<std::string *>(userdata);
+	size_t total_size = size * nmemb;
+	response_body->append(ptr, total_size);
+	return total_size;
 }
 
-// Construct HTTP log message in the same format as DuckDB's HTTPLogType.
-static std::string ConstructHTTPLogMessage(const duckdb_httplib_openssl::Request &request,
-                                           const duckdb_httplib_openssl::Response &response,
-                                           std::chrono::system_clock::time_point start_time,
-                                           std::chrono::system_clock::time_point end_time) {
-	// Format start time as string.
-	auto start_time_t = std::chrono::system_clock::to_time_t(start_time);
-	char start_time_str[64];
-	std::strftime(start_time_str, sizeof(start_time_str), "%Y-%m-%d %H:%M:%S", std::gmtime(&start_time_t));
+// Callback for libcurl to capture response headers.
+struct ResponseHeaders {
+	int32_t status_code = 0;
+	std::string reason;
+	case_insensitive_map_t<std::string> headers;
+};
 
+static size_t HeaderCallback(char *buffer, size_t size, size_t nitems, void *userdata) {
+	auto *resp_headers = static_cast<ResponseHeaders *>(userdata);
+	size_t total_size = size * nitems;
+	std::string header_line(buffer, total_size);
+
+	// Parse HTTP status line (e.g. "HTTP/1.1 200 OK\r\n").
+	if (header_line.substr(0, 5) == "HTTP/") {
+		auto space1 = header_line.find(' ');
+		if (space1 != std::string::npos) {
+			auto space2 = header_line.find(' ', space1 + 1);
+			if (space2 != std::string::npos) {
+				resp_headers->status_code = std::stoi(header_line.substr(space1 + 1, space2 - space1 - 1));
+				auto end = header_line.find_first_of("\r\n", space2 + 1);
+				resp_headers->reason = header_line.substr(space2 + 1, end - space2 - 1);
+			}
+		}
+		return total_size;
+	}
+
+	// Parse regular header (e.g. "Content-Type: application/json\r\n").
+	auto colon = header_line.find(':');
+	if (colon != std::string::npos) {
+		std::string key = header_line.substr(0, colon);
+		std::string value = header_line.substr(colon + 1);
+		// Trim leading/trailing whitespace and CRLF.
+		auto start = value.find_first_not_of(" \t");
+		auto end = value.find_last_not_of(" \t\r\n");
+		if (start != std::string::npos && end != std::string::npos) {
+			value = value.substr(start, end - start + 1);
+		}
+		resp_headers->headers[key] = value;
+	}
+
+	return total_size;
+}
+
+// Construct HTTP log message using DuckDB's Value::STRUCT format for native integration
+// with DuckDB's structured logging (duckdb_logs table).
+static std::string ConstructHTTPLogMessage(const std::string &method, const std::string &url,
+                                           const case_insensitive_map_t<std::string> &request_headers,
+                                           const std::string &request_body,
+                                           std::chrono::system_clock::time_point start_time,
+                                           std::chrono::system_clock::time_point end_time, int32_t status_code,
+                                           const std::string &reason,
+                                           const case_insensitive_map_t<std::string> &response_headers) {
 	// Calculate duration in milliseconds.
 	auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
 
-	// Build request part.
-	std::string log_msg = "{'request': {'type': " + request.method + ", 'url': '" + request.path +
-	                      "', 'headers': " + FormatHeaders(request.headers);
+	// Convert start_time to DuckDB timestamp.
+	auto start_us = std::chrono::duration_cast<std::chrono::microseconds>(start_time.time_since_epoch()).count();
+	auto start_timestamp = Timestamp::FromEpochMicroSeconds(start_us);
 
+	// Build request headers as MAP value.
+	vector<Value> req_header_keys;
+	vector<Value> req_header_values;
+	for (const auto &header : request_headers) {
+		req_header_keys.emplace_back(header.first);
+		req_header_values.emplace_back(header.second);
+	}
+	auto req_headers_value = Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, req_header_keys, req_header_values);
+
+	// Build request struct.
+	child_list_t<Value> request_child_list = {
+	    {"type", Value(method)}, {"url", Value(url)}, {"headers", req_headers_value}};
 	// Only include body if it is not empty.
-	if (!request.body.empty()) {
-		log_msg += ", 'body': '" + request.body + "'";
+	if (!request_body.empty()) {
+		request_child_list.push_back({"body", Value(request_body)});
+	}
+	request_child_list.push_back({"start_time", Value::TIMESTAMP(start_timestamp)});
+	request_child_list.push_back({"duration_ms", Value::BIGINT(duration_ms)});
+	auto request_value = Value::STRUCT(request_child_list);
+
+	// Build response struct (or NULL if no response).
+	Value response_value;
+	if (status_code > 0) {
+		vector<Value> resp_header_keys;
+		vector<Value> resp_header_values;
+		for (const auto &header : response_headers) {
+			resp_header_keys.emplace_back(header.first);
+			resp_header_values.emplace_back(header.second);
+		}
+		auto resp_headers_value =
+		    Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, resp_header_keys, resp_header_values);
+
+		child_list_t<Value> response_child_list = {
+		    {"status", Value(std::to_string(status_code))}, {"reason", Value(reason)}, {"headers", resp_headers_value}};
+		response_value = Value::STRUCT(response_child_list);
 	}
 
-	log_msg += ", 'start_time': '" + std::string(start_time_str) + "', 'duration_ms': " + std::to_string(duration_ms) +
-	           "}, 'response': ";
-
-	// Build response part if we have a valid response.
-	if (response.status != -1) {
-		log_msg += "{'status': " + std::to_string(response.status) + ", 'reason': " + response.reason +
-		           ", 'headers': " + FormatHeaders(response.headers) + "}";
-	} else {
-		log_msg += "NULL";
-	}
-
-	log_msg += "}";
-	return log_msg;
+	child_list_t<Value> child_list = {{"request", request_value}, {"response", response_value}};
+	return Value::STRUCT(child_list).ToString();
 }
 
 ElasticsearchClient::ElasticsearchClient(const ElasticsearchConfig &config, shared_ptr<Logger> logger)
-    : config_(config), logger_(std::move(logger)) {
+    : config_(config), logger_(std::move(logger)), curl_handle_(nullptr) {
+	// Build the base URL once.
+	std::string protocol = config_.use_ssl ? "https" : "http";
+	base_url_ = protocol + "://" + config_.host + ":" + std::to_string(config_.port);
+
+	// Initialize libcurl handle for connection reuse.
+	curl_handle_ = curl_easy_init();
+	if (!curl_handle_) {
+		throw IOException("Failed to initialize libcurl handle");
+	}
+
+	ConfigureCurlHandle();
 }
 
 ElasticsearchClient::~ElasticsearchClient() {
+	if (curl_handle_) {
+		curl_easy_cleanup(curl_handle_);
+		curl_handle_ = nullptr;
+	}
+}
+
+void ElasticsearchClient::ConfigureCurlHandle() {
+	// Configure timeouts (config_.timeout is in milliseconds).
+	curl_easy_setopt(curl_handle_, CURLOPT_TIMEOUT_MS, static_cast<long>(config_.timeout));
+	curl_easy_setopt(curl_handle_, CURLOPT_CONNECTTIMEOUT_MS, static_cast<long>(config_.timeout));
+
+	// SSL verification.
+	if (config_.use_ssl && !config_.verify_ssl) {
+		curl_easy_setopt(curl_handle_, CURLOPT_SSL_VERIFYPEER, 0L);
+		curl_easy_setopt(curl_handle_, CURLOPT_SSL_VERIFYHOST, 0L);
+	} else {
+		curl_easy_setopt(curl_handle_, CURLOPT_SSL_VERIFYPEER, 1L);
+		curl_easy_setopt(curl_handle_, CURLOPT_SSL_VERIFYHOST, 2L);
+	}
+
+	// Follow redirects.
+	curl_easy_setopt(curl_handle_, CURLOPT_FOLLOWLOCATION, 1L);
+
+	// Basic auth.
+	if (!config_.username.empty()) {
+		std::string userpwd = config_.username + ":" + config_.password;
+		curl_easy_setopt(curl_handle_, CURLOPT_USERPWD, userpwd.c_str());
+	}
+
+	// Proxy configuration (from DuckDB's core HTTP proxy settings).
+	if (!config_.proxy_host.empty()) {
+		curl_easy_setopt(curl_handle_, CURLOPT_PROXY, config_.proxy_host.c_str());
+
+		if (!config_.proxy_username.empty()) {
+			std::string proxy_userpwd = config_.proxy_username + ":" + config_.proxy_password;
+			curl_easy_setopt(curl_handle_, CURLOPT_PROXYUSERPWD, proxy_userpwd.c_str());
+		}
+	}
+
+	// Set callbacks.
+	curl_easy_setopt(curl_handle_, CURLOPT_WRITEFUNCTION, WriteCallback);
+	curl_easy_setopt(curl_handle_, CURLOPT_HEADERFUNCTION, HeaderCallback);
+
+	// Enable TCP keep-alive for connection reuse.
+	curl_easy_setopt(curl_handle_, CURLOPT_TCP_KEEPALIVE, 1L);
 }
 
 ElasticsearchResponse ElasticsearchClient::PerformRequest(const std::string &method, const std::string &path,
@@ -87,96 +199,98 @@ ElasticsearchResponse ElasticsearchClient::PerformRequest(const std::string &met
 
 	// Record start time for logging.
 	auto start_time = std::chrono::system_clock::now();
-
-	// Variables to capture request and response details for logging.
-	duckdb_httplib_openssl::Request logged_request;
-	duckdb_httplib_openssl::Response logged_response;
 	bool should_log = logger_ && logger_->ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
 
+	// Track request headers for logging.
+	case_insensitive_map_t<std::string> request_headers;
+	request_headers["Accept"] = "application/json";
+
 	try {
-		// Create client with base URL.
-		std::string protocol = config_.use_ssl ? "https" : "http";
-		std::string base_url = protocol + "://" + config_.host + ":" + std::to_string(config_.port);
-		duckdb_httplib_openssl::Client client(base_url);
+		std::string url = base_url_ + path;
+		std::string response_body;
+		ResponseHeaders resp_headers;
 
-		// Configure timeouts.
-		int timeout_sec = config_.timeout / 1000;
-		int timeout_usec = (config_.timeout % 1000) * 1000;
-		client.set_read_timeout(timeout_sec, timeout_usec);
-		client.set_write_timeout(timeout_sec, timeout_usec);
-		client.set_connection_timeout(timeout_sec, timeout_usec);
+		// Reset handle state for this request (keeps connection alive).
+		curl_easy_setopt(curl_handle_, CURLOPT_URL, url.c_str());
+		curl_easy_setopt(curl_handle_, CURLOPT_WRITEDATA, &response_body);
+		curl_easy_setopt(curl_handle_, CURLOPT_HEADERDATA, &resp_headers);
 
-		// Configure SSL verification.
-		if (config_.use_ssl && !config_.verify_ssl) {
-			client.enable_server_certificate_verification(false);
-		}
+		// Build request headers.
+		struct curl_slist *headers = nullptr;
+		headers = curl_slist_append(headers, "Accept: application/json");
 
-		// Follow redirects.
-		client.set_follow_location(true);
-
-		// Set basic auth if credentials are provided.
-		if (!config_.username.empty()) {
-			client.set_basic_auth(config_.username, config_.password);
-		}
-
-		// Prepare headers.
-		duckdb_httplib_openssl::Headers headers = {{"Accept", "application/json"}};
-
-		if (should_log) {
-			// Set up httplib logger to capture actual request and response details.
-			// Important: This callback is only invoked when requests complete successfully,
-			// failed requests (connection errors, timeouts, SSL failures) are never logged.
-			client.set_logger(
-			    [&](const duckdb_httplib_openssl::Request &req, const duckdb_httplib_openssl::Response &resp) {
-				    logged_request.method = req.method;
-				    logged_request.path = req.path;
-				    logged_request.headers = req.headers;
-				    logged_request.body = req.body;
-				    logged_response.status = resp.status;
-				    logged_response.reason = resp.reason;
-				    logged_response.headers = resp.headers;
-			    });
-		}
-
-		// Make request.
-		duckdb_httplib_openssl::Result result;
-
+		// Configure method and body.
 		if (method == "GET") {
-			result = client.Get(path, headers);
+			curl_easy_setopt(curl_handle_, CURLOPT_HTTPGET, 1L);
+			curl_easy_setopt(curl_handle_, CURLOPT_CUSTOMREQUEST, nullptr);
 		} else if (method == "POST") {
-			result = client.Post(path, headers, body, "application/json");
+			curl_easy_setopt(curl_handle_, CURLOPT_POST, 1L);
+			curl_easy_setopt(curl_handle_, CURLOPT_CUSTOMREQUEST, nullptr);
+			curl_easy_setopt(curl_handle_, CURLOPT_POSTFIELDS, body.c_str());
+			curl_easy_setopt(curl_handle_, CURLOPT_POSTFIELDSIZE, static_cast<long>(body.size()));
+			headers = curl_slist_append(headers, "Content-Type: application/json");
+			request_headers["Content-Type"] = "application/json";
 		} else if (method == "PUT") {
-			result = client.Put(path, headers, body, "application/json");
+			curl_easy_setopt(curl_handle_, CURLOPT_CUSTOMREQUEST, "PUT");
+			curl_easy_setopt(curl_handle_, CURLOPT_POSTFIELDS, body.c_str());
+			curl_easy_setopt(curl_handle_, CURLOPT_POSTFIELDSIZE, static_cast<long>(body.size()));
+			headers = curl_slist_append(headers, "Content-Type: application/json");
+			request_headers["Content-Type"] = "application/json";
 		} else if (method == "DELETE") {
-			result = client.Delete(path, headers, body, "application/json");
+			curl_easy_setopt(curl_handle_, CURLOPT_CUSTOMREQUEST, "DELETE");
+			if (!body.empty()) {
+				curl_easy_setopt(curl_handle_, CURLOPT_POSTFIELDS, body.c_str());
+				curl_easy_setopt(curl_handle_, CURLOPT_POSTFIELDSIZE, static_cast<long>(body.size()));
+				headers = curl_slist_append(headers, "Content-Type: application/json");
+				request_headers["Content-Type"] = "application/json";
+			}
 		} else {
 			response.error_message = "Unsupported HTTP method: " + method;
 			return response;
 		}
 
-		// Process response.
-		if (result) {
-			response.status_code = result->status;
-			response.body = result->body;
-			response.success = (result->status >= 200 && result->status < 300);
+		curl_easy_setopt(curl_handle_, CURLOPT_HTTPHEADER, headers);
+
+		// Perform the request.
+		CURLcode res = curl_easy_perform(curl_handle_);
+
+		// Clean up headers list.
+		curl_slist_free_all(headers);
+
+		if (res == CURLE_OK) {
+			long http_code = 0;
+			curl_easy_getinfo(curl_handle_, CURLINFO_RESPONSE_CODE, &http_code);
+			response.status_code = static_cast<int32_t>(http_code);
+			response.body = std::move(response_body);
+			response.success = (response.status_code >= 200 && response.status_code < 300);
 
 			if (!response.success) {
-				response.error_message = "HTTP " + std::to_string(result->status) + ": " + result->body;
+				response.error_message = "HTTP " + std::to_string(response.status_code) + ": " + response.body;
 			}
 		} else {
-			std::string error_message = duckdb_httplib_openssl::to_string(result.error());
-			response.error_message = "HTTP " + method + " request failed: " + error_message;
+			response.error_message = "HTTP " + method + " request failed: " + std::string(curl_easy_strerror(res));
+		}
+
+		// Log the request (works for both successful and failed requests).
+		if (should_log) {
+			auto end_time = std::chrono::system_clock::now();
+			std::string log_msg =
+			    ConstructHTTPLogMessage(method, path, request_headers, body, start_time, end_time, response.status_code,
+			                            resp_headers.reason, resp_headers.headers);
+			logger_->WriteLog(HTTPLogType::NAME, HTTPLogType::LEVEL, log_msg);
 		}
 
 	} catch (const std::exception &e) {
 		response.error_message = std::string("Exception during HTTP request: ") + e.what();
-	}
 
-	// Log the request after successful completion using details captured by httplib logger.
-	if (should_log && response.status_code > 0) {
-		auto end_time = std::chrono::system_clock::now();
-		std::string log_msg = ConstructHTTPLogMessage(logged_request, logged_response, start_time, end_time);
-		logger_->WriteLog(HTTPLogType::NAME, HTTPLogType::LEVEL, log_msg);
+		// Log even on exception.
+		if (should_log) {
+			auto end_time = std::chrono::system_clock::now();
+			case_insensitive_map_t<std::string> empty_headers;
+			std::string log_msg = ConstructHTTPLogMessage(method, path, request_headers, body, start_time, end_time, 0,
+			                                              "", empty_headers);
+			logger_->WriteLog(HTTPLogType::NAME, HTTPLogType::LEVEL, log_msg);
+		}
 	}
 
 	return response;

--- a/src/elasticsearch_common.cpp
+++ b/src/elasticsearch_common.cpp
@@ -1,13 +1,11 @@
 #include "elasticsearch_common.hpp"
 #include "elasticsearch_cache.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/date.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
-#include <algorithm>
 #include <functional>
 #include <iomanip>
 #include <sstream>

--- a/src/elasticsearch_extension.cpp
+++ b/src/elasticsearch_extension.cpp
@@ -5,13 +5,18 @@
 #include "elasticsearch_query.hpp"
 #include "elasticsearch_optimizer.hpp"
 #include "duckdb.hpp"
-#include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/main/config.hpp"
+
+#include <curl/curl.h>
 
 namespace duckdb {
 
 static void LoadInternal(ExtensionLoader &loader) {
+	// Initialize libcurl globally. This must be called before any libcurl handles are created.
+	// It is safe to call multiple times (curl tracks init count internally).
+	curl_global_init(CURL_GLOBAL_DEFAULT);
+
 	// Register table functions.
 	RegisterElasticsearchQueryFunction(loader);
 

--- a/src/elasticsearch_optimizer.cpp
+++ b/src/elasticsearch_optimizer.cpp
@@ -3,7 +3,6 @@
 #include "duckdb/planner/operator/logical_limit.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
-#include "duckdb/planner/bound_result_modifier.hpp"
 
 namespace duckdb {
 

--- a/src/elasticsearch_query.cpp
+++ b/src/elasticsearch_query.cpp
@@ -2,16 +2,13 @@
 #include "elasticsearch_common.hpp"
 #include "elasticsearch_filter_pushdown.hpp"
 #include "duckdb/function/table_function.hpp"
-#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
-#include "duckdb/main/database.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/main/client_config.hpp"
-#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
-#include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/struct_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
@@ -377,6 +374,11 @@ static unique_ptr<FunctionData> ElasticsearchQueryBind(ClientContext &context, T
 	if (bind_data->index.empty()) {
 		throw InvalidInputException("elasticsearch_query requires 'index' parameter");
 	}
+
+	// Read proxy configuration from DuckDB's core settings.
+	bind_data->config.proxy_host = Settings::Get<HTTPProxySetting>(context);
+	bind_data->config.proxy_username = Settings::Get<HTTPProxyUsernameSetting>(context);
+	bind_data->config.proxy_password = Settings::Get<HTTPProxyPasswordSetting>(context);
 
 	// Resolve schema from Elasticsearch (mapping + document sampling), with caching.
 	// On cache hit, no HTTP requests are made. On cache miss, the mapping is fetched and

--- a/src/include/elasticsearch_client.hpp
+++ b/src/include/elasticsearch_client.hpp
@@ -3,8 +3,8 @@
 #include "duckdb.hpp"
 #include "duckdb/logging/logger.hpp"
 #include <string>
-#include <vector>
-#include <memory>
+
+typedef void CURL;
 
 namespace duckdb {
 
@@ -19,6 +19,9 @@ struct ElasticsearchConfig {
 	int32_t max_retries;         // maximum number of retries for transient errors
 	int32_t retry_interval;      // initial wait time between retries in milliseconds
 	double retry_backoff_factor; // exponential backoff factor applied between retries
+	std::string proxy_host;      // HTTP proxy host
+	std::string proxy_username;  // username for HTTP proxy
+	std::string proxy_password;  // password for HTTP proxy
 };
 
 struct ElasticsearchResponse {
@@ -32,6 +35,10 @@ class ElasticsearchClient {
 public:
 	explicit ElasticsearchClient(const ElasticsearchConfig &config, shared_ptr<Logger> logger = nullptr);
 	~ElasticsearchClient();
+
+	// Disable copy (libcurl handle is not copyable).
+	ElasticsearchClient(const ElasticsearchClient &) = delete;
+	ElasticsearchClient &operator=(const ElasticsearchClient &) = delete;
 
 	// Plain search (no scroll context). Suitable for bounded result sets (e.g. sampling).
 	ElasticsearchResponse Search(const std::string &index, const std::string &query, int64_t size);
@@ -48,14 +55,19 @@ public:
 private:
 	ElasticsearchConfig config_;
 	shared_ptr<Logger> logger_;
+	CURL *curl_handle_;
+	std::string base_url_;
 
-	// Perform HTTP request using httplib with OpenSSL.
+	// Perform HTTP request using libcurl.
 	ElasticsearchResponse PerformRequest(const std::string &method, const std::string &path,
 	                                     const std::string &body = "");
 
 	// Perform request with retry logic for transient errors.
 	ElasticsearchResponse PerformRequestWithRetry(const std::string &method, const std::string &path,
 	                                              const std::string &body = "");
+
+	// Configure the libcurl handle with common options (timeouts, SSL, auth, proxy).
+	void ConfigureCurlHandle();
 };
 
 } // namespace duckdb

--- a/src/include/elasticsearch_common.hpp
+++ b/src/include/elasticsearch_common.hpp
@@ -2,7 +2,6 @@
 
 #include "duckdb.hpp"
 #include "duckdb/common/types/value.hpp"
-#include "duckdb/function/table_function.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "elasticsearch_client.hpp"
 #include "yyjson.hpp"

--- a/src/include/elasticsearch_query.hpp
+++ b/src/include/elasticsearch_query.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "duckdb.hpp"
-#include "duckdb/function/table_function.hpp"
-#include "elasticsearch_client.hpp"
 
 namespace duckdb {
 

--- a/test/sql/client.test
+++ b/test/sql/client.test
@@ -15,13 +15,13 @@ SELECT * FROM elasticsearch_query(
     timeout := 1000
 );
 ----
-connection
+Could not resolve hostname
 
 # Connection should be retried before failing.
 statement error
 SELECT * FROM elasticsearch_query(
     host := 'nonexistent.invalid',
-    port := 99999,
+    port := 19876,
     index := 'test',
     timeout := 1000,
     max_retries := 5
@@ -35,12 +35,12 @@ require-env ELASTICSEARCH_TEST_SERVER_AVAILABLE
 statement error
 SELECT * FROM elasticsearch_query(
     host := 'localhost',
-    port := 99999,
+    port := 19876,
     index := 'test',
     timeout := 1000
 );
 ----
-connection
+Could not connect to server
 
 # Request should fail if authentication credentials are not provided.
 statement error
@@ -74,7 +74,7 @@ SELECT * FROM elasticsearch_query(
     password := 'test'
 );
 ----
-connection
+Timeout was reached
 
 statement ok
 RESET elasticsearch_timeout;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "dependencies": ["openssl"],
+  "dependencies": ["curl"],
   "vcpkg-configuration": {
     "overlay-ports": ["./extension-ci-tools/vcpkg_ports"],
     "overlay-triplets": ["./extension-ci-tools/toolchains"]


### PR DESCRIPTION
Align with the network stack changes introduced in DuckDB v1.5.0 where the default HTTP backend was switched from httplib to curl (https://duckdb.org/2026/03/09/announcing-duckdb-150#network-stack).

This also brings several improvements:
- Connection reuse via persistent curl handle with TCP keep-alive
- Proper proxy support using DuckDB's core HTTP proxy settings
- HTTP logging now uses native integration with structured logging
- Failed requests and exceptions are now logged